### PR TITLE
Added Encode and Decode implementations for f32 and f64.

### DIFF
--- a/src/client/ab_eip/value.rs
+++ b/src/client/ab_eip/value.rs
@@ -236,6 +236,8 @@ impl_atomic!(i32, 4);
 impl_atomic!(u32, 4);
 impl_atomic!(i64, 8);
 impl_atomic!(u64, 8);
+impl_atomic!(f32, 4);
+impl_atomic!(f64, 8);
 
 macro_rules! impl_seq {
     ($ty:tt) => {


### PR DESCRIPTION
The Encode and Decode traits were not correctly implemented for float types. So, I added their implementations using the impl_atomic macro.